### PR TITLE
fix: removed wrong migration file

### DIFF
--- a/src/main/resources/db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml
@@ -1,8 +1,0 @@
-<?xml version="1.1" encoding="UTF-8" standalone="no"?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
-    <changeSet author="IoannisLafiotis" id="removeMonitoring">
-        <sqlFile path="db/changelog/changeset/0004_remove_monitoring/remove-monitoring.sql" stripComments="true"/>
-    </changeSet>
-</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0004_remove_monitoring/remove-monitoring.sql
+++ b/src/main/resources/db/changelog/changeset/0004_remove_monitoring/remove-monitoring.sql
@@ -1,2 +1,0 @@
-ALTER TABLE consultingtypeservice.topic
-    DROP COLUMN monitoring;

--- a/src/main/resources/db/changelog/consultingtypeservice-dev-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-dev-master.xml
@@ -10,5 +10,4 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
-  <include file="db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-local-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-local-master.xml
@@ -10,5 +10,4 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
-  <include file="db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-prod-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-prod-master.xml
@@ -10,5 +10,4 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
-  <include file="db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-staging-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-staging-master.xml
@@ -10,5 +10,4 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
-  <include file="db/changelog/changeset/0004_remove_monitoring/0004-changeSet.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
This Migration file is for an unused mariadb database "consultingtypesservice" and for unused table "topic".
There are no migrations for mongodb collections