### PR TITLE
Bugfix ob 4895 permit topic groups and eager fetch

### DIFF
--- a/.github/workflows/dockerImage.yml
+++ b/.github/workflows/dockerImage.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - "dockerImage.v.*"
       - "v*"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/api/topicservice.yml
+++ b/api/topicservice.yml
@@ -6,6 +6,25 @@ info:
   version: 0.0.1
 
 paths:
+  /topic-groups:
+    get:
+      tags:
+        - topic-groups
+      summary: 'Get all topic groups'
+      operationId: getAllTopicGroups
+      responses:
+        200:
+          description: OK - successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopicGroupsDTO'
+        204:
+          description: NO CONTENT - no content found
+        401:
+          description: UNAUTHORIZED - no/invalid token
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
   /topic:
     get:
       tags:
@@ -195,6 +214,33 @@ paths:
 
 components:
   schemas:
+    TopicGroupsDTO:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          required:
+            - items
+          properties:
+            items:
+              type: array
+              items:
+                type: object
+                required: [ id, name, topicIds ]
+                properties:
+                  id:
+                    type: integer
+                    example: 12132
+                  name:
+                    type: string
+                    example: "Topic group name"
+                    maxLength: 100
+                  topicIds:
+                    type: array
+                    items:
+                      type: integer
     TopicDTO:
       type: object
       required:

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsController.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsController.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Controller for consulting type API requests. */
 @RestController
 @RequiredArgsConstructor
 @Api(tags = "topic-groups")

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsController.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsController.java
@@ -1,0 +1,29 @@
+package de.caritas.cob.consultingtypeservice.api.controller;
+
+import de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter;
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTO;
+import de.caritas.cob.consultingtypeservice.api.service.TopicGroupService;
+import de.caritas.cob.consultingtypeservice.generated.api.controller.TopicGroupsApi;
+import io.swagger.annotations.Api;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller for consulting type API requests. */
+@RestController
+@RequiredArgsConstructor
+@Api(tags = "topic-groups")
+@Slf4j
+public class TopicGroupsController implements TopicGroupsApi {
+
+  private final @NonNull TopicGroupConverter topicGroupConverter;
+  private final @NonNull TopicGroupService topicGroupService;
+
+  @Override
+  public ResponseEntity<TopicGroupsDTO> getAllTopicGroups() {
+    return ResponseEntity.ok(
+        topicGroupConverter.toTopicGroupsDTO(topicGroupService.getAllTopicGroups()));
+  }
+}

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
@@ -5,7 +5,6 @@ import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTO;
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTOData;
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTODataItemsInner;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 import lombok.val;
 import org.springframework.stereotype.Component;
@@ -15,7 +14,7 @@ public class TopicGroupConverter {
 
   public TopicGroupsDTO toTopicGroupsDTO(Collection<TopicGroupEntity> topicGroups) {
     val tg = new TopicGroupsDTO();
-    List<TopicGroupsDTODataItemsInner> items =
+    val items =
         topicGroups.stream()
             .map(
                 topicGroup ->

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
@@ -1,0 +1,32 @@
+package de.caritas.cob.consultingtypeservice.api.converter;
+
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTO;
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTOData;
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTODataItemsInner;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.val;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TopicGroupConverter {
+
+  public TopicGroupsDTO toTopicGroupsDTO(Collection<TopicGroupEntity> topicGroups) {
+    val tg = new TopicGroupsDTO();
+    List<TopicGroupsDTODataItemsInner> items =
+        topicGroups.stream()
+            .map(
+                topicGroup ->
+                    new TopicGroupsDTODataItemsInner()
+                        .topicIds(
+                            topicGroup.getTopicEntities().stream()
+                                .map(topicEntity -> topicEntity.getId().intValue())
+                                .collect(Collectors.toList()))
+                        .id(topicGroup.getId().intValue())
+                        .name(topicGroup.getName()))
+            .collect(Collectors.toList());
+    return tg.data(new TopicGroupsDTOData().items(items));
+  }
+}

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/converter/TopicGroupConverter.java
@@ -5,27 +5,32 @@ import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTO;
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTOData;
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupsDTODataItemsInner;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
-import lombok.val;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TopicGroupConverter {
 
   public TopicGroupsDTO toTopicGroupsDTO(Collection<TopicGroupEntity> topicGroups) {
-    val tg = new TopicGroupsDTO();
-    val items =
-        topicGroups.stream()
-            .map(
-                topicGroup ->
-                    new TopicGroupsDTODataItemsInner()
-                        .topicIds(
-                            topicGroup.getTopicEntities().stream()
-                                .map(topicEntity -> topicEntity.getId().intValue())
-                                .collect(Collectors.toList()))
-                        .id(topicGroup.getId().intValue())
-                        .name(topicGroup.getName()))
-            .collect(Collectors.toList());
-    return tg.data(new TopicGroupsDTOData().items(items));
+    return new TopicGroupsDTO().data(new TopicGroupsDTOData().items(itemsOf(topicGroups)));
+  }
+
+  private static List<TopicGroupsDTODataItemsInner> itemsOf(
+      Collection<TopicGroupEntity> topicGroups) {
+    return topicGroups.stream()
+        .map(
+            topicGroup ->
+                new TopicGroupsDTODataItemsInner()
+                    .topicIds(topicIdsOf(topicGroup))
+                    .id(topicGroup.getId().intValue())
+                    .name(topicGroup.getName()))
+        .collect(Collectors.toList());
+  }
+
+  private static List<Integer> topicIdsOf(TopicGroupEntity topicGroup) {
+    return topicGroup.getTopicEntities().stream()
+        .map(topicEntity -> topicEntity.getId().intValue())
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
@@ -54,6 +54,6 @@ public class TopicEntity implements TenantAware {
   @Column(name = "update_date")
   private LocalDateTime updateDate;
 
-  @ManyToMany(mappedBy = "topicEntities")
+  @ManyToMany(mappedBy = "topicEntities", fetch = FetchType.EAGER)
   Set<TopicGroupEntity> topicGroupEntities;
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
@@ -2,15 +2,8 @@ package de.caritas.cob.consultingtypeservice.api.model;
 
 import de.caritas.cob.consultingtypeservice.api.repository.TenantAware;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import java.util.Set;
+import javax.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -60,4 +53,7 @@ public class TopicEntity implements TenantAware {
 
   @Column(name = "update_date")
   private LocalDateTime updateDate;
+
+  @ManyToMany(mappedBy = "topicEntities")
+  Set<TopicGroupEntity> topicEntities;
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicEntity.java
@@ -55,5 +55,5 @@ public class TopicEntity implements TenantAware {
   private LocalDateTime updateDate;
 
   @ManyToMany(mappedBy = "topicEntities")
-  Set<TopicGroupEntity> topicEntities;
+  Set<TopicGroupEntity> topicGroupEntities;
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicGroupEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicGroupEntity.java
@@ -1,0 +1,34 @@
+package de.caritas.cob.consultingtypeservice.api.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "topic_group")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class TopicGroupEntity {
+
+  @Id
+  @SequenceGenerator(name = "id_seq", allocationSize = 1, sequenceName = "SEQUENCE_TOPIC_GROUP")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "name", nullable = false, length = 100)
+  private String name;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @Column(name = "update_date")
+  private LocalDateTime updateDate;
+
+  @OneToMany(targetEntity = TopicEntity.class, fetch = FetchType.LAZY)
+  private List<TopicEntity> topicEntities;
+}

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicGroupEntity.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/model/TopicGroupEntity.java
@@ -1,7 +1,8 @@
 package de.caritas.cob.consultingtypeservice.api.model;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import javax.persistence.*;
 import lombok.*;
 
@@ -29,6 +30,10 @@ public class TopicGroupEntity {
   @Column(name = "update_date")
   private LocalDateTime updateDate;
 
-  @OneToMany(targetEntity = TopicEntity.class, fetch = FetchType.LAZY)
-  private List<TopicEntity> topicEntities;
+  @ManyToMany
+  @JoinTable(
+      name = "topic_group_x_topic",
+      joinColumns = @JoinColumn(name = "group_id"),
+      inverseJoinColumns = @JoinColumn(name = "topic_id"))
+  private Set<TopicEntity> topicEntities = new HashSet<>();
 }

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepository.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepository.java
@@ -1,0 +1,6 @@
+package de.caritas.cob.consultingtypeservice.api.repository;
+
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TopicGroupRepository extends JpaRepository<TopicGroupEntity, Long> {}

--- a/src/main/java/de/caritas/cob/consultingtypeservice/api/service/TopicGroupService.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/api/service/TopicGroupService.java
@@ -1,0 +1,21 @@
+package de.caritas.cob.consultingtypeservice.api.service;
+
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
+import de.caritas.cob.consultingtypeservice.api.repository.TopicGroupRepository;
+import java.util.Collection;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TopicGroupService {
+
+  private @NonNull TopicGroupRepository topicGroupRepository;
+
+  public Collection<TopicGroupEntity> getAllTopicGroups() {
+    return topicGroupRepository.findAll();
+  }
+}

--- a/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
@@ -75,6 +75,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .authenticated()
         .requestMatchers(new AntPathRequestMatcher("/topic/*"))
         .authenticated()
+        .requestMatchers(new AntPathRequestMatcher("/topic-groups"))
+        .authenticated()
         .requestMatchers(new AntPathRequestMatcher("/topicadmin"))
         .authenticated()
         .requestMatchers(new AntPathRequestMatcher("/topicadmin/*"))

--- a/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
+++ b/src/main/java/de/caritas/cob/consultingtypeservice/config/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
         .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topic/*")))
         .permitAll()
+        .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topic-groups")))
+        .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topicadmin")))
         .permitAll()
         .requestMatchers(new NegatedRequestMatcher(new AntPathRequestMatcher("/topicadmin/*")))

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+  <changeSet author="dodalovicgran" id="topicGroups">
+    <sqlFile
+      path="db/changelog/changeset/0004_topic_groups/topicGroups.sql"
+      stripComments="true"/>
+    <rollback>
+      <sqlFile path="db/changelog/changeset/0004_topic_groups/topicGroups-rollback.sql" stripComments="true"/>
+    </rollback>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups-rollback.sql
@@ -1,0 +1,1 @@
+drop table if exists `consultingtypeservice`.`group_topic`, `consultingtypeservice`.`group`;

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
@@ -18,12 +18,10 @@ CREATE SEQUENCE consultingtypeservice.sequence_topic_group
 
 CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`topic_group_x_topic`
 (
-    `id`          bigint(21) NOT NULL,
     `group_id`    bigint(21) NOT NULL,
     `topic_id`    bigint(21) NOT NULL,
     `create_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
     `update_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
-    PRIMARY KEY (`id`),
     KEY `group_id` (`group_id`),
     CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `topic_group` (`id`) ON UPDATE CASCADE,
     KEY `topic_id` (`topic_id`),

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
@@ -23,9 +23,9 @@ CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`topic_group_x_topic`
     `create_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
     `update_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
     KEY `group_id` (`group_id`),
-    CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `topic_group` (`id`) ON UPDATE CASCADE,
+    CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `topic_group` (`id`) ON UPDATE CASCADE ON DELETE CASCADE,
     KEY `topic_id` (`topic_id`),
-    CONSTRAINT `fk_topic` FOREIGN KEY (`topic_id`) REFERENCES `topic` (`id`) ON UPDATE CASCADE
+    CONSTRAINT `fk_topic` FOREIGN KEY (`topic_id`) REFERENCES `topic` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8
   COLLATE = utf8_unicode_ci;

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
@@ -1,0 +1,44 @@
+/* group */
+
+CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group`
+(
+    `id`          bigint(21)                           NOT NULL,
+    `name`        varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+    `create_date` datetime                             NOT NULL DEFAULT (UTC_TIMESTAMP),
+    `update_date` datetime                             NOT NULL DEFAULT (UTC_TIMESTAMP),
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COLLATE = utf8_unicode_ci;
+
+CREATE SEQUENCE consultingtypeservice.sequence_group
+    INCREMENT BY 1
+    MINVALUE = 0
+    NOMAXVALUE
+    START WITH 0
+    CACHE 0;
+
+/* group_topic */
+
+CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group_topic`
+(
+    `id`          bigint(21) NOT NULL,
+    `group_id`    bigint(21) NOT NULL,
+    `topic_id`    bigint(21) NOT NULL,
+    `create_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
+    `update_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
+    PRIMARY KEY (`id`),
+    KEY `group_id` (`group_id`),
+    CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `group` (`id`) ON UPDATE CASCADE,
+    KEY `topic_id` (`topic_id`),
+    CONSTRAINT `fk_topic` FOREIGN KEY (`topic_id`) REFERENCES `topic` (`id`) ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8
+  COLLATE = utf8_unicode_ci;
+
+CREATE SEQUENCE `consultingtypeservice`.`sequence_group_topic`
+    INCREMENT BY 1
+    MINVALUE = 0
+    NOMAXVALUE
+    START WITH 0
+    CACHE 10;

--- a/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
+++ b/src/main/resources/db/changelog/changeset/0004_topic_groups/topicGroups.sql
@@ -1,6 +1,4 @@
-/* group */
-
-CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group`
+CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`topic_group`
 (
     `id`          bigint(21)                           NOT NULL,
     `name`        varchar(100) COLLATE utf8_unicode_ci NOT NULL,
@@ -11,16 +9,14 @@ CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group`
   DEFAULT CHARSET = utf8
   COLLATE = utf8_unicode_ci;
 
-CREATE SEQUENCE consultingtypeservice.sequence_group
+CREATE SEQUENCE consultingtypeservice.sequence_topic_group
     INCREMENT BY 1
     MINVALUE = 0
     NOMAXVALUE
     START WITH 0
     CACHE 0;
 
-/* group_topic */
-
-CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group_topic`
+CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`topic_group_x_topic`
 (
     `id`          bigint(21) NOT NULL,
     `group_id`    bigint(21) NOT NULL,
@@ -29,14 +25,14 @@ CREATE TABLE IF NOT EXISTS `consultingtypeservice`.`group_topic`
     `update_date` datetime   NOT NULL DEFAULT (UTC_TIMESTAMP),
     PRIMARY KEY (`id`),
     KEY `group_id` (`group_id`),
-    CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `group` (`id`) ON UPDATE CASCADE,
+    CONSTRAINT `fk_group` FOREIGN KEY (`group_id`) REFERENCES `topic_group` (`id`) ON UPDATE CASCADE,
     KEY `topic_id` (`topic_id`),
     CONSTRAINT `fk_topic` FOREIGN KEY (`topic_id`) REFERENCES `topic` (`id`) ON UPDATE CASCADE
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8
   COLLATE = utf8_unicode_ci;
 
-CREATE SEQUENCE `consultingtypeservice`.`sequence_group_topic`
+CREATE SEQUENCE `consultingtypeservice`.`sequence_topic_group_x_topic`
     INCREMENT BY 1
     MINVALUE = 0
     NOMAXVALUE

--- a/src/main/resources/db/changelog/consultingtypeservice-dev-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-dev-master.xml
@@ -8,6 +8,6 @@
     <!-- The base changeset contains the database state when liquibase was added to the project -->
 	<include file="db/changelog/changeset/0001_initsql/initSql.xml"/>
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
-  <include
-    file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
+  <include file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
+  <include file="/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-local-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-local-master.xml
@@ -10,4 +10,5 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
+  <include file="/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-prod-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-prod-master.xml
@@ -10,4 +10,5 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
+    <include file="/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-staging-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-staging-master.xml
@@ -10,4 +10,5 @@
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
   <include
     file="db/changelog/changeset/0003_migrate_topic_to_multilingual_structure/0003-changeSet.xml"/>
+    <include file="/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/consultingtypeservice-testing-master.xml
+++ b/src/main/resources/db/changelog/consultingtypeservice-testing-master.xml
@@ -8,4 +8,5 @@
     <!-- The base changeset contains the database state when liquibase was added to the project -->
 	<include file="db/changelog/changeset/0001_initsql/initSql.xml"/>
   <include file="db/changelog/changeset/0002_topic_internal_identifier/topic_internal_identifier_column.xml"/>
+  <include file="/db/changelog/changeset/0004_topic_groups/0004-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsControllerIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsControllerIT.java
@@ -15,6 +15,7 @@ import de.caritas.cob.consultingtypeservice.api.service.TopicGroupService;
 import de.caritas.cob.consultingtypeservice.api.tenant.TenantContext;
 import java.util.List;
 import java.util.Set;
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,34 +49,32 @@ class TopicGroupsControllerIT {
 
   @Test
   void getAllTopicGroups_Should_ReturnTopicGroupsDTO_When_UserIsAuthenticated() throws Exception {
-    /* arrange */
-    var tge1 = new TopicGroupEntity();
-    tge1.setId(1L);
-    tge1.setName("1");
-    var te1 = new TopicEntity();
-    te1.setId(1L);
-    var te2 = new TopicEntity();
-    te2.setId(2L);
-    tge1.setTopicEntities(Set.of(te1, te2));
+    /* given */
+    val tge1 =
+        TopicGroupEntity.builder()
+            .id(1L)
+            .name("1")
+            .topicEntities(
+                Set.of(TopicEntity.builder().id(1L).build(), TopicEntity.builder().id(2L).build()))
+            .build();
+    val tge2 =
+        TopicGroupEntity.builder()
+            .id(2L)
+            .name("2")
+            .topicEntities(
+                Set.of(TopicEntity.builder().id(3L).build(), TopicEntity.builder().id(4L).build()))
+            .build();
 
-    var tge2 = new TopicGroupEntity();
-    tge2.setId(2L);
-    tge2.setName("2");
-    var te3 = new TopicEntity();
-    te3.setId(3L);
-    var te4 = new TopicEntity();
-    te4.setId(4L);
-    tge2.setTopicEntities(Set.of(te3, te4));
     when(topicGroupService.getAllTopicGroups()).thenReturn(List.of(tge1, tge2));
 
     final AuthenticationMockBuilder builder = new AuthenticationMockBuilder();
-    /* act */
+    /* when */
     mockMvc
         .perform(
             get("/topic-groups")
                 .with(authentication(builder.withUserRole(UserRole.TOPIC_ADMIN.getValue()).build()))
                 .accept(MediaType.APPLICATION_JSON))
-        /* assert */
+        /* then */
         .andExpect(status().isOk())
         .andExpect(
             content()
@@ -85,10 +84,10 @@ class TopicGroupsControllerIT {
 
   @Test
   void getTopicList_Should_ReturnForbidden_When_UserIsNotAuthenticated() throws Exception {
-    /* arrange, act */
+    /* when */
     mockMvc
         .perform(get("/topic-groups").accept(MediaType.APPLICATION_JSON))
-        /* assert */
+        /* then */
         .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsControllerIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/controller/TopicGroupsControllerIT.java
@@ -1,0 +1,94 @@
+package de.caritas.cob.consultingtypeservice.api.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.caritas.cob.consultingtypeservice.ConsultingTypeServiceApplication;
+import de.caritas.cob.consultingtypeservice.api.auth.UserRole;
+import de.caritas.cob.consultingtypeservice.api.model.TopicEntity;
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
+import de.caritas.cob.consultingtypeservice.api.service.TopicGroupService;
+import de.caritas.cob.consultingtypeservice.api.tenant.TenantContext;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest(classes = ConsultingTypeServiceApplication.class)
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@TestPropertySource(properties = "multitenancy.enabled=false")
+@TestPropertySource(properties = "feature.multitenancy.with.single.domain.enabled=true")
+@AutoConfigureMockMvc(addFilters = false)
+class TopicGroupsControllerIT {
+
+  private MockMvc mockMvc;
+
+  @Autowired private WebApplicationContext context;
+
+  @MockBean TopicGroupService topicGroupService;
+
+  @BeforeEach
+  public void setup() {
+    TenantContext.clear();
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void getAllTopicGroups_Should_ReturnTopicGroupsDTO_When_UserIsAuthenticated() throws Exception {
+    /* arrange */
+    var tge1 = new TopicGroupEntity();
+    tge1.setId(1L);
+    tge1.setName("1");
+    var te1 = new TopicEntity();
+    te1.setId(1L);
+    var te2 = new TopicEntity();
+    te2.setId(2L);
+    tge1.setTopicEntities(Set.of(te1, te2));
+
+    var tge2 = new TopicGroupEntity();
+    tge2.setId(2L);
+    tge2.setName("2");
+    var te3 = new TopicEntity();
+    te3.setId(3L);
+    var te4 = new TopicEntity();
+    te4.setId(4L);
+    tge2.setTopicEntities(Set.of(te3, te4));
+    when(topicGroupService.getAllTopicGroups()).thenReturn(List.of(tge1, tge2));
+
+    final AuthenticationMockBuilder builder = new AuthenticationMockBuilder();
+    /* act */
+    mockMvc
+        .perform(
+            get("/topic-groups")
+                .with(authentication(builder.withUserRole(UserRole.TOPIC_ADMIN.getValue()).build()))
+                .accept(MediaType.APPLICATION_JSON))
+        /* assert */
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .json(
+                    "{\"data\":{\"items\":[{\"id\":1,\"name\":\"1\",\"topicIds\":[2,1]},{\"id\":2,\"name\":\"2\",\"topicIds\":[4,3]}]}}"));
+  }
+
+  @Test
+  void getTopicList_Should_ReturnForbidden_When_UserIsNotAuthenticated() throws Exception {
+    /* arrange, act */
+    mockMvc
+        .perform(get("/topic-groups").accept(MediaType.APPLICATION_JSON))
+        /* assert */
+        .andExpect(status().isForbidden());
+  }
+}

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
@@ -1,0 +1,31 @@
+package de.caritas.cob.consultingtypeservice.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@TestPropertySource(properties = "spring.profiles.active=testing")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class TopicGroupRepositoryIT {
+
+  public static final String NEW_TOPIC_NAME = "a new topic";
+
+  @Autowired private TopicRepository topicRepository;
+  @Autowired private TopicGroupRepository topicGroupRepository;
+
+  @Test
+  void topicGroupRepositoryReturnsEmptyListForNoTopicGroups() {
+    val topicGroups = topicGroupRepository.findAll();
+    // then
+    assertThat(topicGroups).isEmpty();
+  }
+}

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
@@ -2,6 +2,9 @@ package de.caritas.cob.consultingtypeservice.api.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
+import java.time.LocalDateTime;
+import java.util.Set;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,8 +20,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @DataJpaTest
 class TopicGroupRepositoryIT {
 
-  public static final String NEW_TOPIC_NAME = "a new topic";
-
   @Autowired private TopicRepository topicRepository;
   @Autowired private TopicGroupRepository topicGroupRepository;
 
@@ -27,5 +28,45 @@ class TopicGroupRepositoryIT {
     val topicGroups = topicGroupRepository.findAll();
     // then
     assertThat(topicGroups).isEmpty();
+  }
+
+  @Test
+  void topicGroupRepositoryReturnsSomeMeaningfulData() {
+    val topics = topicRepository.findAll();
+    val now = LocalDateTime.now();
+    val tg1 =
+        topicGroupRepository.saveAndFlush(
+            TopicGroupEntity.builder()
+                .name("tg1")
+                .topicEntities(Set.of(topics.get(0), topics.get(1)))
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    val tg2 =
+        topicGroupRepository.saveAndFlush(
+            TopicGroupEntity.builder()
+                .name("tg2")
+                .topicEntities(Set.of(topics.get(2)))
+                .createDate(now)
+                .updateDate(now)
+                .build());
+    assertThat(tg1)
+        .satisfies(
+            tge -> {
+              assertThat(tge.getId()).isNotNull();
+              assertThat(tge.getName()).isEqualTo("tg1");
+              assertThat(tge.getCreateDate()).isEqualTo(now);
+              assertThat(tge.getUpdateDate()).isEqualTo(now);
+              assertThat(tge.getTopicEntities()).hasSize(2).contains(topics.get(0), topics.get(1));
+            });
+    assertThat(tg2)
+        .satisfies(
+            tge -> {
+              assertThat(tge.getId()).isNotNull();
+              assertThat(tge.getName()).isEqualTo("tg2");
+              assertThat(tge.getCreateDate()).isEqualTo(now);
+              assertThat(tge.getUpdateDate()).isEqualTo(now);
+              assertThat(tge.getTopicEntities()).hasSize(1).contains(topics.get(2));
+            });
   }
 }

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
@@ -2,11 +2,13 @@ package de.caritas.cob.consultingtypeservice.api.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import de.caritas.cob.consultingtypeservice.api.model.TopicEntity;
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,12 @@ class TopicGroupRepositoryIT {
   @Autowired private TopicRepository topicRepository;
   @Autowired private TopicGroupRepository topicGroupRepository;
 
+  @BeforeEach
+  void setup() {
+    topicGroupRepository.deleteAll();
+    topicRepository.deleteAll();
+  }
+
   @Test
   void topicGroupRepositoryReturnsEmptyListForNoTopicGroups() {
     // when
@@ -34,44 +42,122 @@ class TopicGroupRepositoryIT {
 
   @Test
   void topicGroupRepositoryReturnsSomeMeaningfulData() {
-    // given
-    val topics = topicRepository.findAll();
     val now = LocalDateTime.now();
-    topicGroupRepository.saveAllAndFlush(
-        List.of(
-            TopicGroupEntity.builder()
-                .name("tg1")
-                .topicEntities(Set.of(topics.get(0), topics.get(1)))
-                .createDate(now)
-                .updateDate(now)
-                .build(),
-            TopicGroupEntity.builder()
-                .name("tg2")
-                .topicEntities(Set.of(topics.get(2)))
-                .createDate(now)
-                .updateDate(now)
-                .build()));
+    val te1 = TopicEntity.builder().name("te1").createDate(now).updateDate(now).build();
+    val te2 = TopicEntity.builder().name("te2").createDate(now).updateDate(now).build();
+
+    topicRepository.saveAllAndFlush(List.of(te1, te2));
+
+    var tg1 =
+        TopicGroupEntity.builder()
+            .name("tg1")
+            .createDate(now)
+            .updateDate(now)
+            .topicEntities(Set.of(te1, te2))
+            .build();
+
+    topicGroupRepository.saveAllAndFlush(List.of(tg1));
 
     /* when */
     val topicGroups = topicGroupRepository.findAll();
 
     /* then */
 
-    val tg1 = getTopicGroupEntityByName(topicGroups, "tg1");
+    tg1 = getTopicGroupEntityByName(topicGroups, "tg1");
 
     assertThat(tg1.getId()).isNotNull();
     assertThat(tg1.getName()).isEqualTo("tg1");
     assertThat(tg1.getCreateDate()).isEqualTo(now);
     assertThat(tg1.getUpdateDate()).isEqualTo(now);
-    assertThat(tg1.getTopicEntities()).hasSize(2).contains(topics.get(0), topics.get(1));
+    assertThat(tg1.getTopicEntities()).hasSize(2).contains(te1, te2);
+  }
 
-    val tg2 = getTopicGroupEntityByName(topicGroups, "tg2");
+  @Test
+  void deletingTopicGroupKeepsTopicsUntouched() {
+    /* given */
+    val now = LocalDateTime.now();
+    val te1 = TopicEntity.builder().name("te1").createDate(now).updateDate(now).build();
+    val te2 = TopicEntity.builder().name("te2").createDate(now).updateDate(now).build();
+    val te3 = TopicEntity.builder().name("te3").createDate(now).updateDate(now).build();
+    val te4 = TopicEntity.builder().name("te4").createDate(now).updateDate(now).build();
 
-    assertThat(tg2.getId()).isNotNull();
-    assertThat(tg2.getName()).isEqualTo("tg2");
-    assertThat(tg2.getCreateDate()).isEqualTo(now);
-    assertThat(tg2.getUpdateDate()).isEqualTo(now);
-    assertThat(tg2.getTopicEntities()).hasSize(1).contains(topics.get(2));
+    topicRepository.saveAllAndFlush(List.of(te1, te2, te3, te4));
+
+    val tg1 =
+        TopicGroupEntity.builder()
+            .name("tg1")
+            .createDate(now)
+            .updateDate(now)
+            .topicEntities(Set.of(te1, te2))
+            .build();
+    val tg2 =
+        TopicGroupEntity.builder()
+            .name("tg2")
+            .createDate(now)
+            .updateDate(now)
+            .topicEntities(Set.of(te3, te4))
+            .build();
+
+    topicGroupRepository.saveAllAndFlush(List.of(tg1, tg2));
+
+    val allTopics = topicRepository.findAll();
+    val allTopicGroups = topicGroupRepository.findAll();
+
+    assertThat(allTopics).hasSize(4);
+    assertThat(allTopicGroups).hasSize(2);
+
+    topicGroupShouldContainTopics(allTopicGroups, "tg1", te1, te2);
+    topicGroupShouldContainTopics(allTopicGroups, "tg2", te3, te4);
+
+    /* when */
+    topicGroupRepository.delete(tg1);
+
+    /* then */
+    assertThat(topicGroupRepository.findAll()).containsOnly(tg2);
+    assertThat(topicRepository.findAll()).containsOnly(te1, te2, te3, te4);
+
+    topicGroupShouldContainTopics(topicGroupRepository.findAll(), "tg2", te3, te4);
+  }
+
+  @Test
+  void deletingTopicGetsItRemovedFromGroup() {
+    /* given */
+    val now = LocalDateTime.now();
+    val te1 = TopicEntity.builder().name("te1").createDate(now).updateDate(now).build();
+    val te2 = TopicEntity.builder().name("te2").createDate(now).updateDate(now).build();
+
+    topicRepository.saveAllAndFlush(List.of(te1, te2));
+
+    val tg1 =
+        TopicGroupEntity.builder()
+            .name("tg1")
+            .createDate(now)
+            .updateDate(now)
+            .topicEntities(Set.of(te1, te2))
+            .build();
+
+    topicGroupRepository.saveAndFlush(tg1);
+
+    val allTopics = topicRepository.findAll();
+    val allTopicGroups = topicGroupRepository.findAll();
+
+    assertThat(allTopics).hasSize(2);
+    assertThat(allTopicGroups).hasSize(1);
+
+    topicGroupShouldContainTopics(allTopicGroups, "tg1", te1, te2);
+
+    /* when */
+    topicRepository.delete(te1);
+
+    /* then */
+    assertThat(topicGroupRepository.findAll()).containsOnly(tg1);
+    assertThat(topicRepository.findAll()).containsOnly(te2);
+  }
+
+  private void topicGroupShouldContainTopics(
+      List<TopicGroupEntity> topicGroups, String topicGroupName, TopicEntity... topics) {
+    val topicGroup = getTopicGroupEntityByName(topicGroups, topicGroupName);
+    assertThat(topicGroup.getTopicEntities()).hasSize(topics.length).contains(topics);
   }
 
   private static TopicGroupEntity getTopicGroupEntityByName(

--- a/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
+++ b/src/test/java/de/caritas/cob/consultingtypeservice/api/repository/TopicGroupRepositoryIT.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.val;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ class TopicGroupRepositoryIT {
 
   @Test
   void topicGroupRepositoryReturnsEmptyListForNoTopicGroups() {
+    // when
     val topicGroups = topicGroupRepository.findAll();
     // then
     assertThat(topicGroups).isEmpty();
@@ -32,41 +34,51 @@ class TopicGroupRepositoryIT {
 
   @Test
   void topicGroupRepositoryReturnsSomeMeaningfulData() {
+    // given
     val topics = topicRepository.findAll();
     val now = LocalDateTime.now();
-    val tg1 =
-        topicGroupRepository.saveAndFlush(
+    topicGroupRepository.saveAllAndFlush(
+        List.of(
             TopicGroupEntity.builder()
                 .name("tg1")
                 .topicEntities(Set.of(topics.get(0), topics.get(1)))
                 .createDate(now)
                 .updateDate(now)
-                .build());
-    val tg2 =
-        topicGroupRepository.saveAndFlush(
+                .build(),
             TopicGroupEntity.builder()
                 .name("tg2")
                 .topicEntities(Set.of(topics.get(2)))
                 .createDate(now)
                 .updateDate(now)
-                .build());
-    assertThat(tg1)
-        .satisfies(
-            tge -> {
-              assertThat(tge.getId()).isNotNull();
-              assertThat(tge.getName()).isEqualTo("tg1");
-              assertThat(tge.getCreateDate()).isEqualTo(now);
-              assertThat(tge.getUpdateDate()).isEqualTo(now);
-              assertThat(tge.getTopicEntities()).hasSize(2).contains(topics.get(0), topics.get(1));
-            });
-    assertThat(tg2)
-        .satisfies(
-            tge -> {
-              assertThat(tge.getId()).isNotNull();
-              assertThat(tge.getName()).isEqualTo("tg2");
-              assertThat(tge.getCreateDate()).isEqualTo(now);
-              assertThat(tge.getUpdateDate()).isEqualTo(now);
-              assertThat(tge.getTopicEntities()).hasSize(1).contains(topics.get(2));
-            });
+                .build()));
+
+    /* when */
+    val topicGroups = topicGroupRepository.findAll();
+
+    /* then */
+
+    val tg1 = getTopicGroupEntityByName(topicGroups, "tg1");
+
+    assertThat(tg1.getId()).isNotNull();
+    assertThat(tg1.getName()).isEqualTo("tg1");
+    assertThat(tg1.getCreateDate()).isEqualTo(now);
+    assertThat(tg1.getUpdateDate()).isEqualTo(now);
+    assertThat(tg1.getTopicEntities()).hasSize(2).contains(topics.get(0), topics.get(1));
+
+    val tg2 = getTopicGroupEntityByName(topicGroups, "tg2");
+
+    assertThat(tg2.getId()).isNotNull();
+    assertThat(tg2.getName()).isEqualTo("tg2");
+    assertThat(tg2.getCreateDate()).isEqualTo(now);
+    assertThat(tg2.getUpdateDate()).isEqualTo(now);
+    assertThat(tg2.getTopicEntities()).hasSize(1).contains(topics.get(2));
+  }
+
+  private static TopicGroupEntity getTopicGroupEntityByName(
+      List<TopicGroupEntity> topicGroups, String topicGroupName) {
+    return topicGroups.stream()
+        .filter(topicGroupEntity -> topicGroupEntity.getName().equals(topicGroupName))
+        .findFirst()
+        .orElseThrow();
   }
 }

--- a/src/test/resources/database/TopicDatabase.sql
+++ b/src/test/resources/database/TopicDatabase.sql
@@ -2,45 +2,27 @@ DROP TABLE IF EXISTS `topic`;
 
 CREATE TABLE IF NOT EXISTS `topic`
 (
-    `id` bigint
-(
-    21
-) NOT NULL,
-    `tenant_id` bigint
-(
-    21
-) NULL,
-    `name` varchar
-(
-    100
-) NOT NULL,
-    `description` varchar
-(
-    100
-) NULL,
-    `status` varchar
-(
-    20
-),
-    `create_date` datetime NOT NULL,
-    `update_date` datetime NULL,
-    `internal_identifier` varchar
-(
-    50
-) NULL,
+    `id`                  bigint(21)   NOT NULL,
+    `tenant_id`           bigint(21)   NULL,
+    `name`                varchar(100) NOT NULL,
+    `description`         varchar(100) NULL,
+    `status`              varchar(20),
+    `create_date`         datetime     NOT NULL,
+    `update_date`         datetime     NULL,
+    `internal_identifier` varchar(50)  NULL,
     PRIMARY KEY
-(
-    `id`
-)
-    );
+        (
+         `id`
+            )
+);
 
 
 ALTER TABLE `topic`
     ADD CONSTRAINT IF NOT EXISTS unique_name_per_tenant UNIQUE (name, tenant_id);
 
 CREATE SEQUENCE IF NOT EXISTS sequence_topic
-INCREMENT BY 1
-START WITH 100000;
+    INCREMENT BY 1
+    START WITH 100000;
 
 INSERT INTO TOPIC (`id`, `tenant_id`, `name`, `description`, `status`, `create_date`)
 VALUES (1, '1', '{"de" : "de an active topic", "en": "en an active topic"}',
@@ -53,3 +35,35 @@ VALUES (2, '1', '{"de" : "de not an active topic", "en": "en not an active topic
 
 INSERT INTO TOPIC (`id`, `tenant_id`, `name`, `description`, `status`, `create_date`)
 VALUES (3, '2', '{"de" : "de another topic"}', '{"de" : "de description"}', 'ACTIVE', '2022-06-02');
+
+DROP TABLE IF EXISTS `topic_group`;
+CREATE TABLE IF NOT EXISTS topic_group
+(
+    `id`          bigint(21)   NOT NULL,
+    `name`        varchar(100) NOT NULL,
+    `create_date` datetime     NOT NULL,
+    `tenant_id`   bigint(21)   NULL,
+    `update_date` datetime     NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE SEQUENCE sequence_topic_group
+    INCREMENT BY 1
+    START WITH 1;
+
+DROP TABLE IF EXISTS topic_group_x_topic;
+CREATE TABLE IF NOT EXISTS topic_group_x_topic
+(
+    id       bigint(21) NOT NULL,
+    group_id bigint(21) NOT NULL,
+    topic_id bigint(21) NOT NULL,
+    create_date datetime   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_date datetime   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    foreign key (group_id) references topic_group (id),
+    foreign key (topic_id) references topic (id)
+);
+
+CREATE SEQUENCE sequence_topic_group_x_topic
+    INCREMENT BY 1
+    START WITH 1;

--- a/src/test/resources/database/TopicDatabase.sql
+++ b/src/test/resources/database/TopicDatabase.sql
@@ -56,8 +56,8 @@ CREATE TABLE IF NOT EXISTS topic_group_x_topic
 (
     group_id bigint(21) NOT NULL,
     topic_id bigint(21) NOT NULL,
-    foreign key (group_id) references topic_group (id),
-    foreign key (topic_id) references topic (id)
+    foreign key (group_id) references topic_group (id) ON UPDATE CASCADE ON DELETE CASCADE,
+    foreign key (topic_id) references topic (id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
 CREATE SEQUENCE sequence_topic_group_x_topic

--- a/src/test/resources/database/TopicDatabase.sql
+++ b/src/test/resources/database/TopicDatabase.sql
@@ -1,4 +1,8 @@
+DROP TABLE IF EXISTS topic_group_x_topic;
 DROP TABLE IF EXISTS `topic`;
+DROP TABLE IF EXISTS `topic_group`;
+DROP SEQUENCE IF EXISTS sequence_topic_group_x_topic;
+DROP SEQUENCE IF EXISTS sequence_topic_group;
 
 CREATE TABLE IF NOT EXISTS `topic`
 (
@@ -10,15 +14,13 @@ CREATE TABLE IF NOT EXISTS `topic`
     `create_date`         datetime     NOT NULL,
     `update_date`         datetime     NULL,
     `internal_identifier` varchar(50)  NULL,
-    PRIMARY KEY
-        (
-         `id`
-            )
+    PRIMARY KEY (`id`)
 );
 
-
 ALTER TABLE `topic`
-    ADD CONSTRAINT IF NOT EXISTS unique_name_per_tenant UNIQUE (name, tenant_id);
+    ALTER COLUMN `create_date` SET DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `topic`
+    ALTER COLUMN `update_date` SET DEFAULT CURRENT_TIMESTAMP;
 
 CREATE SEQUENCE IF NOT EXISTS sequence_topic
     INCREMENT BY 1
@@ -36,7 +38,6 @@ VALUES (2, '1', '{"de" : "de not an active topic", "en": "en not an active topic
 INSERT INTO TOPIC (`id`, `tenant_id`, `name`, `description`, `status`, `create_date`)
 VALUES (3, '2', '{"de" : "de another topic"}', '{"de" : "de description"}', 'ACTIVE', '2022-06-02');
 
-DROP TABLE IF EXISTS `topic_group`;
 CREATE TABLE IF NOT EXISTS topic_group
 (
     `id`          bigint(21)   NOT NULL,
@@ -51,15 +52,10 @@ CREATE SEQUENCE sequence_topic_group
     INCREMENT BY 1
     START WITH 1;
 
-DROP TABLE IF EXISTS topic_group_x_topic;
 CREATE TABLE IF NOT EXISTS topic_group_x_topic
 (
-    id       bigint(21) NOT NULL,
     group_id bigint(21) NOT NULL,
     topic_id bigint(21) NOT NULL,
-    create_date datetime   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    update_date datetime   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (id),
     foreign key (group_id) references topic_group (id),
     foreign key (topic_id) references topic (id)
 );


### PR DESCRIPTION
@tkuzynow We got this thingy:

```
2023-06-06 12:35:15.661  WARN 1 --- [nio-8080-exec-1] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:01.767  WARN 1 --- [nio-8080-exec-2] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:03.774  WARN 1 --- [nio-8080-exec-3] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:36:14.511  WARN 1 --- [nio-8080-exec-4] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:37:52.118  WARN 1 --- [nio-8080-exec-6] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:41:15.007  WARN 1 --- [nio-8080-exec-1] o.s.web.servlet.PageNotFound             : Request method 'GET' not supported
2023-06-06 12:45:20.843  INFO 1 --- [io-8080-exec-10] o.keycloak.adapters.KeycloakDeployment   : Loaded URLs from https://dev.diakonie.dev.virtual-identity.com/auth/realms/online-beratung/.well-known/openid-configuration
2023-06-06 12:45:21.088 ERROR 1 --- [io-8080-exec-10] d.c.c.c.api.service.LogService           : ConsultingTypeService API: 500 Internal Server Error: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: de.caritas.cob.consultingtypeservice.api.model.TopicGroupEntity.topicEntities, could not initialize proxy - no Session
	at org.hibernate.collection.internal.AbstractPersistentCollection.throwLazyInitializationException(AbstractPersistentCollection.java:606)
	at org.hibernate.collection.internal.AbstractPersistentCollection.withTemporarySessionIfNeeded(AbstractPersistentCollection.java:218)
	at org.hibernate.collection.internal.AbstractPersistentCollection.initialize(AbstractPersistentCollection.java:585)
	at org.hibernate.collection.internal.AbstractPersistentCollection.read(AbstractPersistentCollection.java:149)
	at org.hibernate.collection.internal.PersistentSet.iterator(PersistentSet.java:188)
	at java.base/java.util.Spliterators$IteratorSpliterator.estimateSize(Spliterators.java:1821)
	at java.base/java.util.Spliterator.getExactSizeIfKnown(Spliterator.java:408)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:483)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.topicIdsOf(TopicGroupConverter.java:34)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.lambda$itemsOf$0(TopicGroupConverter.java:25)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.itemsOf(TopicGroupConverter.java:28)
	at de.caritas.cob.consultingtypeservice.api.converter.TopicGroupConverter.toTopicGroupsDTO(TopicGroupConverter.java:16)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController.getAllTopicGroups(TopicGroupsController.java:26)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController$$FastClassBySpringCGLIB$$2eb3232c.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.validation.beanvalidation.MethodValidationInterceptor.invoke(MethodValidationInterceptor.java:123)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708)
	at de.caritas.cob.consultingtypeservice.api.controller.TopicGroupsController$$EnhancerBySpringCGLIB$$f5e7b4c0.getAllTopicGroups(<generated>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:655)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:764)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticatedActionsFilter.doFilter(KeycloakAuthenticatedActionsFilter.java:74)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
```